### PR TITLE
include all gif and png in assets precompilation

### DIFF
--- a/lib/fcfinder/engine.rb
+++ b/lib/fcfinder/engine.rb
@@ -4,7 +4,7 @@ module Fcfinder
       #app.config.assets.precompile += %w(../../vendor/assets/fcfinder/*)
       #app.config.assets.precompile += %w(../vendor/assets/images/fcfinder/*)
       #app.config.assets.precompile += %w(fcfinder.css.erb)
-      app.config.assets.precompile += %w(assets/images/fcfinder/*)
+      app.config.assets.precompile += %w(*.gif *.png)
       app.config.assets.precompile += %w(fcfinder.css)
       app.config.assets.precompile += %w(fcfinder.js)
     end


### PR DESCRIPTION
Without this modification the asset images of FCFinder does not seem to get included during the precpompilation 